### PR TITLE
use native net/http persistence when available

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -458,8 +458,16 @@ class ThreeScale::ClientTest < MiniTest::Unit::TestCase
   end
 end
 
-class ThreeScale::PersistentClientTest < ThreeScale::ClientTest
+class ThreeScale::NetHttpPersistentClientTest < ThreeScale::ClientTest
   def client(options = {})
+    ThreeScale::Client::HTTPClient.persistent_backend = ThreeScale::Client::HTTPClient::NetHttpPersistent
     ThreeScale::Client.new({:provider_key => '1234abcd', :persistent => true}.merge(options))
+  end
+end
+
+class ThreeScale::NetHttpKeepAliveClientTest < ThreeScale::NetHttpPersistentClientTest
+  def client(options = {})
+    ThreeScale::Client::HTTPClient.persistent_backend = ThreeScale::Client::HTTPClient::NetHttpKeepAlive
+    super
   end
 end

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -1,16 +1,19 @@
 require 'minitest/autorun'
 
 require '3scale/client'
+require 'mocha/setup'
 
 if ENV['TEST_3SCALE_PROVIDER_KEY'] && ENV['TEST_3SCALE_APP_IDS'] && ENV['TEST_3SCALE_APP_KEYS']
-  class ThreeScale::PersistenceTest < MiniTest::Unit::TestCase
+  class ThreeScale::NetHttpPersistenceTest < MiniTest::Unit::TestCase
     def setup
+      ThreeScale::Client::HTTPClient.persistent_backend = ThreeScale::Client::HTTPClient::NetHttpPersistent
+
       provider_key = ENV['TEST_3SCALE_PROVIDER_KEY']
 
       @app_id = ENV['TEST_3SCALE_APP_IDS']
       @app_key = ENV['TEST_3SCALE_APP_KEYS']
 
-      @client = ThreeScale::Client.new(:provider_key => provider_key, :persistence => true)
+      @client = ThreeScale::Client.new(provider_key: provider_key, persistence: true)
 
       if defined?(FakeWeb)
         FakeWeb.allow_net_connect = true
@@ -25,6 +28,14 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] && ENV['TEST_3SCALE_APP_IDS'] && ENV['TEST_3S
       assert @client.authorize(:app_id => @app_id, :app_key => @app_key).success?
       sleep 70
       assert @client.authorize(:app_id => @app_id, :app_key => @app_key).success?
+    end
+  end
+
+
+  class ThreeScale::NetHttpKeepaliveTest < ThreeScale::NetHttpPersistenceTest
+    def setup
+      ThreeScale::Client::HTTPClient.persistent_backend = ThreeScale::Client::HTTPClient::NetHttpKeepAlive
+      super
     end
   end
 end


### PR DESCRIPTION
This enables native net/http keep_alive on ruby >= 2.0 (without need for net-http-persistent).

```
Rehearsal ----------------------------------------------------
http               0.010000   0.000000   0.010000 (  2.524337)
http+persistent    0.000000   0.000000   0.000000 (  1.370789)
https+persistent   0.010000   0.010000   0.020000 (  1.350326)
https              0.020000   0.000000   0.020000 (  4.913202)
------------------------------------------- total: 0.050000sec

                       user     system      total        real
http               0.010000   0.010000   0.020000 (  2.811026)
http+persistent    0.000000   0.000000   0.000000 (  1.283812)
https+persistent   0.010000   0.000000   0.010000 (  1.654703)
https              0.020000   0.000000   0.020000 (  3.669459)
```

/cc @unleashed @areina 