### PR TITLE
Complete support for log field in transactions

### DIFF
--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -275,6 +275,10 @@ module ThreeScale
         transaction[:usage].each do |name, value|
           append_encoded_value(result, index, [:usage, name], value)
         end
+
+        transaction.fetch(:log, {}).each do |name, value|
+          append_encoded_value(result, index, [:log, name], value)
+        end
       end
 
       result

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -5,7 +5,7 @@ require 'mocha/setup'
 
 require '3scale/client'
 
-class ThreeScale::ClientTest < MiniTest::Unit::TestCase
+class ThreeScale::ClientTest < MiniTest::Test
 
   def client(options = {})
     ThreeScale::Client.new({:provider_key => '1234abcd'}.merge(options))

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -342,6 +342,9 @@ class ThreeScale::ClientTest < MiniTest::Unit::TestCase
       'transactions[0][app_id]'      => 'foo',
       'transactions[0][timestamp]'   => CGI.escape('2010-04-27 15:42:17 0200'),
       'transactions[0][usage][hits]' => '1',
+      'transactions[0][log][request]'  => 'foo',
+      'transactions[0][log][response]' => 'bar',
+      'transactions[0][log][code]'   => '200',
       'transactions[1][app_id]'      => 'bar',
       'transactions[1][timestamp]'   => CGI.escape('2010-04-27 15:55:12 0200'),
       'transactions[1][usage][hits]' => '1',
@@ -354,7 +357,13 @@ class ThreeScale::ClientTest < MiniTest::Unit::TestCase
 
     @client.report({:app_id    => 'foo',
                     :usage     => {'hits' => 1},
-                    :timestamp => '2010-04-27 15:42:17 0200'},
+                    :timestamp => '2010-04-27 15:42:17 0200',
+                    :log       => {
+                      'request'  => 'foo',
+                      'response' => 'bar',
+                      'code'     => 200,
+                    }
+                   },
 
                    {:app_id    => 'bar',
                     :usage     => {'hits' => 1},

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require '3scale/middleware'
 require 'mocha/setup'
 
-class ThreeScale::MiddlewareTest < MiniTest::Unit::TestCase
+class ThreeScale::MiddlewareTest < MiniTest::Test
 
   def setup
     @app = ->(_env) {  [ 200, {}, ['']] }

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -4,7 +4,7 @@ require '3scale/client'
 require 'mocha/setup'
 
 if ENV['TEST_3SCALE_PROVIDER_KEY'] && ENV['TEST_3SCALE_APP_IDS'] && ENV['TEST_3SCALE_APP_KEYS']
-  class ThreeScale::NetHttpPersistenceTest < MiniTest::Unit::TestCase
+  class ThreeScale::NetHttpPersistenceTest < MiniTest::Test
     def setup
       ThreeScale::Client::HTTPClient.persistent_backend = ThreeScale::Client::HTTPClient::NetHttpPersistent
 

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -82,7 +82,9 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
 
     def test_successful_report
       transactions = @app_ids.map do |app_id|
-        {:app_id => app_id, :usage => {'hits' => 1}}
+        {:app_id => app_id,
+         :usage => {'hits' => 1},
+         :log => {:request => "a/a", :response => "b/b", :code => 200 }}
       end
 
       response = @client.report(*transactions)

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -4,7 +4,7 @@ require '3scale/client'
 if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
    ENV['TEST_3SCALE_APP_IDS']      &&
    ENV['TEST_3SCALE_APP_KEYS']
-  class ThreeScale::RemoteTest < MiniTest::Unit::TestCase
+  class ThreeScale::RemoteTest < MiniTest::Test
     def setup
       @provider_key = ENV['TEST_3SCALE_PROVIDER_KEY']
 


### PR DESCRIPTION
It was already implemented for `authrep` method but not for
`report`.