### PR TITLE
Change `append_encoded_value` by `append_value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased][unreleased]
 ### Fixed
+- Fixed double escaping of post parameters (https://github.com/3scale/3scale_ws_api_for_ruby/pull/24)
 ### Added
 
 ## [2.6.0] - 2015-12-28

--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -268,24 +268,24 @@ module ThreeScale
       result = {}
 
       transactions.each_with_index do |transaction, index|
-        append_encoded_value(result, index, [:app_id],    transaction[:app_id])
-        append_encoded_value(result, index, [:timestamp], transaction[:timestamp])
-        append_encoded_value(result, index, [:client_ip], transaction[:client_ip])
+        append_value(result, index, [:app_id],    transaction[:app_id])
+        append_value(result, index, [:timestamp], transaction[:timestamp])
+        append_value(result, index, [:client_ip], transaction[:client_ip])
 
         transaction[:usage].each do |name, value|
-          append_encoded_value(result, index, [:usage, name], value)
+          append_value(result, index, [:usage, name], value)
         end
 
         transaction.fetch(:log, {}).each do |name, value|
-          append_encoded_value(result, index, [:log, name], value)
+          append_value(result, index, [:log, name], value)
         end
       end
 
       result
     end
 
-    def append_encoded_value(result, index, names, value)
-      result["transactions[#{index}][#{names.join('][')}]"] = CGI.escape(value.to_s) if value
+    def append_value(result, index, names, value)
+      result["transactions[#{index}][#{names.join('][')}]"] = value if value
     end
 
     def build_report_response


### PR DESCRIPTION
Internally, http client calls to `URI.encode_www_form` and this encodes
values properly, we don't need to do it by ourselves.

There was an issue with that and timestamps, because the final value
wasn't correct.

Ex:

valid:

URI.encode_www_form({timestamp: Time.now})
=> "timestamp=2016-01-04+15%3A01%3A49+%2B0000"

invalid:

URI.encode_www_form({timestamp: CGI.escape(Time.now.to_s)})
=> "timestamp=2016-01-04%2B15%253A01%253A38%2B%252B0000"