### PR TITLE
Added support for 'user_key' authentication mode in 'report' method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased][unreleased]
 ### Fixed
 ### Added
+- Added support for 'user_key' authentication mode in 'report' method
 
 ## [2.6.1] - 2016-01-04
 ### Fixed

--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -249,6 +249,7 @@ module ThreeScale
 
     OAUTH_PARAMS = [:app_id, :app_key, :service_id, :redirect_url]
     ALL_PARAMS = [:user_key, :app_id, :app_key, :service_id, :redirect_url]
+    REPORT_PARAMS = [:user_key, :app_id, :service_id, :timestamp]
 
     def options_to_params(options, allowed_keys)
       params = { :provider_key  => provider_key }
@@ -268,9 +269,9 @@ module ThreeScale
       result = {}
 
       transactions.each_with_index do |transaction, index|
-        append_value(result, index, [:app_id],    transaction[:app_id])
-        append_value(result, index, [:timestamp], transaction[:timestamp])
-        append_value(result, index, [:client_ip], transaction[:client_ip])
+        REPORT_PARAMS.each do |param|
+          append_value(result, index, [param],  transaction[param])
+        end
 
         transaction[:usage].each do |name, value|
           append_value(result, index, [:usage, name], value)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -370,6 +370,26 @@ class ThreeScale::ClientTest < MiniTest::Test
     assert_equal URI.encode_www_form(payload), request.body
   end
 
+  def test_report_supports_user_key
+    payload = {
+      'transactions[0][user_key]'    => 'foo',
+      'transactions[0][timestamp]'   => '2016-07-18 15:42:17 0200',
+      'transactions[0][usage][hits]' => '1',
+      'provider_key'                 => '1234abcd'
+    }
+
+    FakeWeb.register_uri(:post, "http://#{@host}/transactions.xml",
+                         :status => ['200', 'OK'])
+
+    @client.report({:user_key    => 'foo',
+                    :usage     => {'hits' => 1},
+                    :timestamp => '2016-07-18 15:42:17 0200'})
+
+    request = FakeWeb.last_request
+
+    assert_equal URI.encode_www_form(payload), request.body
+  end
+
   def test_failed_report
     error_body = '<error code="provider_key_invalid">provider key "foo" is invalid</error>'
 


### PR DESCRIPTION
Closes https://github.com/3scale/3scale_ws_api_for_ruby/issues/20