### PR TITLE
Accept service id in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Added support for reporting to services other than the default one.
+  `ThreeScale::Client#report` now accepts an optional `service_id`.
+  There has been a change in the params that the method accepts. This
+  change is backwards compatible but a deprecation warning is shown
+  when calling the method using the old params.
+
 ## [2.7.0] - 2016-08-26
 ### Added
 - Added support for 'user_key' authentication mode in 'report' method

--- a/README.md
+++ b/README.md
@@ -197,19 +197,30 @@ response.redirect_url
 
 ### Report
 
-To report usage, use the +report+ method. You can report multiple transaction at the same time:
+To report usage, use the +report+ method. You can report multiple transactions at the same time:
 
 ```ruby
-response = client.report({:app_id => "first app id",  :usage => {'hits' => 1}},
-                         {:app_id => "second app id", :usage => {'hits' => 1}})
+response = client.report(
+  :transactions => [{:app_id => "first app id",  :usage => {'hits' => 1}},
+                    {:app_id => "second app id", :usage => {'hits' => 1}}])
+```
+
+To specify a service other than the default one:
+```ruby
+response = client.report(
+  :transactions => [{:app_id => "first app id",  :usage => {'hits' => 1}},
+                    {:app_id => "second app id", :usage => {'hits' => 1}}],
+  :service_id => 'service_123')
 ```
 
 The :app_id and :usage parameters are required. Additionaly, you can specify a timestamp
-of transaction:
+of a transaction:
 
 ```ruby
-response = client.report({:app_id => "app id", :usage => {'hits' => 1},
-                          :timestamp => Time.local(2010, 4, 28, 12, 36)})
+response = client.report(
+  :transactions => [{:app_id => "app id",
+                     :usage => {'hits' => 1},
+                     :timestamp => Time.local(2010, 4, 28, 12, 36)}])
 ```
 
 The timestamp can be either a Time object (from ruby's standard library) or something that

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -87,7 +87,7 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
          :log => {:request => "a/a", :response => "b/b", :code => 200 }}
       end
 
-      response = @client.report(*transactions)
+      response = @client.report(transactions: transactions)
       assert response.success?
     end
 
@@ -97,7 +97,7 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
       end
 
       client   = ThreeScale::Client.new(:provider_key => 'invalid-key')
-      response = client.report(*transactions)
+      response = client.report(transactions: transactions)
       assert !response.success?
       assert_equal 'provider_key_invalid',                  response.error_code
       assert_equal 'provider key "invalid-key" is invalid', response.error_message


### PR DESCRIPTION
Closes https://github.com/3scale/3scale_ws_api_for_ruby/issues/29

This breaks compatibility with previous versions, as it introduces a new parameter in `ThreeScale::Client#report`. If this is merged, we should release a new major version.