### PR TITLE
Performance optimization for building auths reponses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Changed
+- Improved parsing performance of the response of the authorize call.
+
 ## [2.8.0] - 2016-09-06
 This version drops support for Ruby versions < 2.0.
 
@@ -12,7 +16,7 @@ This version drops support for Ruby versions < 2.0.
   when calling the method using the old params.
 - The two authorize calls `ThreeScale::Client#Authorize` and
   `ThreeScale::Client#oauth_authorize` now accept an optional predicted
-  usage parameter.  
+  usage parameter.
 - It is now possible to specify a port different that the default
   one for the API service management endpoint.
 

--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -352,10 +352,13 @@ module ThreeScale
       response.plan = doc.at_css('plan').content.to_s.strip
 
       doc.css('usage_reports usage_report').each do |node|
+        period_start = node.at('period_start')
+        period_end = node.at('period_end')
+
         response.add_usage_report(:metric        => node['metric'].to_s.strip,
                                   :period        => node['period'].to_s.strip.to_sym,
-                                  :period_start  => node.at('period_start') ? node.at('period_start').content : '' ,
-                                  :period_end    => node.at('period_end') ? node.at('period_end').content : '',
+                                  :period_start  => period_start ? period_start.content : '',
+                                  :period_end    => period_end ? period_end.content : '',
                                   :current_value => node.at('current_value').content.to_i,
                                   :max_value     => node.at('max_value').content.to_i)
       end


### PR DESCRIPTION
For each usage report, we were checking twice the `period_start` and `period_end` elements.