### PR TITLE
Add support for 'hierarchy' option in authorize calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Added support for retrieving metric hierarchies in authorize calls.
+  This is an experimental feature and its support is not guaranteed for
+  future releases.
+
 ## [2.8.1] - 2016-10-11
 ### Changed
 - Improved parsing performance of the response of the authorize call.

--- a/lib/3scale/authorize_response.rb
+++ b/lib/3scale/authorize_response.rb
@@ -5,12 +5,19 @@ module ThreeScale
     def initialize
       super
       @usage_reports = []
+
+      # hierarchy is a hash where the keys are metric names, and the values
+      # their children (array of metric names).
+      # Only metrics that have at least one child appear as keys.
+      @hierarchy = {}
     end
 
     attr_accessor :plan
     attr_accessor :app_key
     attr_accessor :redirect_url
     attr_accessor :service_id
+    attr_reader :usage_reports
+    attr_reader :hierarchy # Not part of the stable API
 
     class UsageReport
       attr_reader :metric
@@ -37,10 +44,12 @@ module ThreeScale
       end
     end
 
-    attr_reader :usage_reports
-
     def add_usage_report(options)
       @usage_reports << UsageReport.new(options)
+    end
+
+    def add_metric_to_hierarchy(metric_name, children)
+      @hierarchy[metric_name] = children
     end
   end
 end

--- a/lib/3scale/authorize_response.rb
+++ b/lib/3scale/authorize_response.rb
@@ -2,23 +2,6 @@ require 'time'
 
 module ThreeScale
   class AuthorizeResponse < Response
-    def initialize
-      super
-      @usage_reports = []
-
-      # hierarchy is a hash where the keys are metric names, and the values
-      # their children (array of metric names).
-      # Only metrics that have at least one child appear as keys.
-      @hierarchy = {}
-    end
-
-    attr_accessor :plan
-    attr_accessor :app_key
-    attr_accessor :redirect_url
-    attr_accessor :service_id
-    attr_reader :usage_reports
-    attr_reader :hierarchy # Not part of the stable API
-
     class UsageReport
       attr_reader :metric
       attr_reader :period
@@ -42,6 +25,23 @@ module ThreeScale
       def exceeded?
         current_value > max_value
       end
+    end
+
+    attr_accessor :plan
+    attr_accessor :app_key
+    attr_accessor :redirect_url
+    attr_accessor :service_id
+    attr_reader :usage_reports
+    attr_reader :hierarchy # Not part of the stable API
+
+    def initialize
+      super
+      @usage_reports = []
+
+      # hierarchy is a hash where the keys are metric names, and the values
+      # their children (array of metric names).
+      # Only metrics that have at least one child appear as keys.
+      @hierarchy = {}
     end
 
     def add_usage_report(options)

--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -275,8 +275,10 @@ module ThreeScale
 
     private
 
-    OAUTH_PARAMS = [:app_id, :app_key, :service_id, :redirect_url, :usage]
-    ALL_PARAMS = [:user_key, :app_id, :app_key, :service_id, :redirect_url, :usage]
+    # The support for the 'hierarchy' param is experimental. Its support is not
+    # guaranteed for future versions.
+    OAUTH_PARAMS = [:app_id, :app_key, :service_id, :redirect_url, :usage, :hierarchy]
+    ALL_PARAMS = [:user_key, :app_id, :app_key, :service_id, :redirect_url, :usage, :hierarchy]
     REPORT_PARAMS = [:user_key, :app_id, :service_id, :timestamp]
 
     def options_to_params(options, allowed_keys)
@@ -361,6 +363,12 @@ module ThreeScale
                                   :period_end    => period_end ? period_end.content : '',
                                   :current_value => node.at('current_value').content.to_i,
                                   :max_value     => node.at('max_value').content.to_i)
+      end
+
+      doc.css('hierarchy metric').each do |node|
+        metric_name = node['name'].to_s.strip
+        children = node['children'].to_s.strip.split(' ')
+        response.add_metric_to_hierarchy(metric_name, children)
       end
 
       response


### PR DESCRIPTION
This PR adds support for the 'hierarchy' option in authorize calls. It allows us to retrieve the hierarchy of metrics (parents/children) for which there's a usage limit that applies directly or through the parent.

This feature is not part of the stable API. Its subject to change.