### PR TITLE
Add AuthorizeResponse#limits_exceeded? helper

### DIFF
--- a/lib/3scale/authorize_response.rb
+++ b/lib/3scale/authorize_response.rb
@@ -27,6 +27,13 @@ module ThreeScale
       end
     end
 
+    # These 2 constants are defined according to what the 3scale
+    # backend returns in the response of authorize calls.
+    LIMITS_EXCEEDED = 'limits_exceeded'.freeze
+    private_constant :LIMITS_EXCEEDED
+    LIMITS_EXCEEDED_MSG = 'usage limits are exceeded'.freeze
+    private_constant :LIMITS_EXCEEDED_MSG
+
     attr_accessor :plan
     attr_accessor :app_key
     attr_accessor :redirect_url
@@ -50,6 +57,12 @@ module ThreeScale
 
     def add_metric_to_hierarchy(metric_name, children)
       @hierarchy[metric_name] = children
+    end
+
+    # The response already specifies whether any usage report (if present)
+    # is over the limits, so use that instead of scanning the reports.
+    def limits_exceeded?
+      error_code == LIMITS_EXCEEDED || error_message == LIMITS_EXCEEDED_MSG
     end
   end
 end

--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -92,7 +92,7 @@ module ThreeScale
       when Net::HTTPSuccess,Net::HTTPConflict
         build_authorize_response(http_response.body)
       when Net::HTTPClientError
-        build_error_response(http_response.body)
+        build_error_response(http_response.body, AuthorizeResponse)
       else
         raise ServerError.new(http_response)
       end
@@ -218,7 +218,7 @@ module ThreeScale
       when Net::HTTPSuccess,Net::HTTPConflict
         build_authorize_response(http_response.body)
       when Net::HTTPClientError
-        build_error_response(http_response.body)
+        build_error_response(http_response.body, AuthorizeResponse)
       else
         raise ServerError.new(http_response)
       end
@@ -267,7 +267,7 @@ module ThreeScale
       when Net::HTTPSuccess,Net::HTTPConflict
         build_authorize_response(http_response.body)
       when Net::HTTPClientError
-        build_error_response(http_response.body)
+        build_error_response(http_response.body, AuthorizeResponse)
       else
         raise ServerError.new(http_response)
       end
@@ -374,11 +374,11 @@ module ThreeScale
       response
     end
 
-    def build_error_response(body)
+    def build_error_response(body, klass = Response)
       doc = Nokogiri::XML(body)
       node = doc.at_css('error')
 
-      response = Response.new
+      response = klass.new
       response.error!(node.content.to_s.strip, node['code'].to_s.strip)
       response
     end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -119,6 +119,7 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = @client.authorize(:app_id => 'foo')
 
     assert response.success?
+    assert !response.limits_exceeded?
     assert_equal 'Ultimate', response.plan
     assert_equal 2, response.usage_reports.size
 
@@ -188,8 +189,9 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = @client.authorize(:app_id => 'foo')
 
     assert !response.success?
+    assert response.limits_exceeded?
     assert_equal 'usage limits are exceeded', response.error_message
-    assert response.usage_reports[0].exceeded?
+    assert response.usage_reports.any? { |report| report.exceeded? }
   end
 
   def test_authorize_with_invalid_app_id
@@ -200,6 +202,7 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = @client.authorize(:app_id => 'foo')
 
     assert !response.success?
+    assert !response.limits_exceeded?
     assert_equal 'application_not_found',                   response.error_code
     assert_equal 'application with id="foo" was not found', response.error_message
   end
@@ -227,6 +230,7 @@ class ThreeScale::ClientTest < MiniTest::Test
                                  :usage => { 'metric1' => 1, 'metric2' => 2 })
 
     assert response.success?
+    assert !response.limits_exceeded?
   end
 
   def test_authorize_with_usage_and_limits_exceeded
@@ -254,6 +258,7 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = @client.authorize(:app_id => 'foo', :usage => { 'hits' => 1 })
 
     assert !response.success?
+    assert response.limits_exceeded?
     assert_equal 'usage limits are exceeded', response.error_message
   end
 
@@ -347,6 +352,7 @@ class ThreeScale::ClientTest < MiniTest::Test
 
     response = @client.oauth_authorize(:app_id => 'foo', :redirect_url => "http://localhost:8080/oauth/oauth_redirect")
     assert response.success?
+    assert !response.limits_exceeded?
 
     assert_equal '883bdb8dbc3b6b77dbcf26845560fdbb', response.app_key
     assert_equal 'http://localhost:8080/oauth/oauth_redirect', response.redirect_url
@@ -399,8 +405,9 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = @client.oauth_authorize(:app_id => 'foo')
 
     assert !response.success?
+    assert response.limits_exceeded?
     assert_equal 'usage limits are exceeded', response.error_message
-    assert response.usage_reports[0].exceeded?
+    assert response.usage_reports.any? { |report| report.exceeded? }
   end
 
   def test_oauth_authorize_with_invalid_app_id
@@ -411,6 +418,7 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = @client.oauth_authorize(:app_id => 'foo')
 
     assert !response.success?
+    assert !response.limits_exceeded?
     assert_equal 'application_not_found',                   response.error_code
     assert_equal 'application with id="foo" was not found', response.error_message
   end
@@ -439,6 +447,7 @@ class ThreeScale::ClientTest < MiniTest::Test
         :app_id => 'foo', :usage => { 'metric1' => 1, 'metric2' => 2 })
 
     assert response.success?
+    assert !response.limits_exceeded?
   end
 
   def test_oauth_authorize_with_usage_and_limits_exceeded
@@ -467,6 +476,7 @@ class ThreeScale::ClientTest < MiniTest::Test
                                        :usage => { 'hits' => 1 })
 
     assert !response.success?
+    assert response.limits_exceeded?
     assert_equal 'usage limits are exceeded', response.error_message
   end
 
@@ -653,6 +663,7 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = client.authorize(:app_id => 'foo')
 
     assert response.success?
+    assert !response.limits_exceeded?
     request = FakeWeb.last_request
     assert_equal "plugin-ruby-v#{version}", request["X-3scale-User-Agent"]
     assert_equal "su1.3scale.net", request["host"]
@@ -685,6 +696,7 @@ class ThreeScale::ClientTest < MiniTest::Test
     response = client.authrep(:app_id => 'abc')
 
     assert response.success?
+    assert !response.limits_exceeded?
     request = FakeWeb.last_request
     assert_equal "plugin-ruby-v#{version}", request["X-3scale-User-Agent"]
     assert_equal "su1.3scale.net", request["host"]


### PR DESCRIPTION
This adds a helper method we found quite useful in users of this gem.

This checks the error code to see whether the response of an authorization request is `limits_exceeded` (as opposed to checking each usage report separately, because 3scale's backend will do that for you and use the `code` field). However, we are also checking the message because we noticed that there seems to be a bug in which the code would be `nil` but the error message would be ok. (that needs to be investigated).