### PR TITLE
Fix Travis tests to include Ruby 2.1+ and JRuby 9.1.1.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,25 @@
+sudo: required
+dist: trusty
 language: ruby
+before_install: gem install -N bundler -v '~> 1.11'
 cache: bundler
-sudo: false
 rvm:
-- 2.0.0
-- 2.1
-- 2.2
-- 2.3.0
-- jruby
+  - 2.1
+  - 2.2
+  - 2.3
+  - jruby-9.1.5.0
+jdk:
+  - oraclejdk8
 gemfile:
   - Gemfile
   - gemfiles/rack_1.gemfile
 matrix:
   exclude:
-  - rvm: 2.0.0
-    gemfile: Gemfile
   - rvm: 2.1
     gemfile: Gemfile
   - rvm: 2.2
-    gemfile: Gemfile
-  - rvm: jruby
     gemfile: Gemfile
 env:
   global:
     - TEST_3SCALE_APP_IDS=4d4b20b9 TEST_3SCALE_APP_KEYS=ecce202ecc2eb8dc7a499c34a34d5987
     - secure: VSElS0KvnufcZKStV7kj6xHFEiWvQkpxk1IEuhKq5JqywniN/6ScaNUFxbBKrOUrqhzXIRUCteBP2wvYRjlNhLFZSnYskzh7dLkOp/WV+WK6KjrdflTiF6UTxW4pBSsg6YDJ/wWJlmwsPVty1pRvOE3ru6uco+dTWCCLn4BvWqc=
-    - JRUBY_OPTS="--2.0"

--- a/3scale_client.gemspec
+++ b/3scale_client.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.1'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "fakeweb"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Analytics Setup: https://support.3scale.net/quickstarts/3scale-api-analytics
 
 ## Installation
 
-This library is distributed as a gem:
+This library is distributed as a gem, for which Ruby 2.1 or JRuby 9.1.1.0 are
+minimum requirements:
 ```sh
 gem install 3scale_client
 ```


### PR DESCRIPTION
These are the minimum versions that can be supported with the current indirect dependencies.