### PR TITLE
Extensions support

### DIFF
--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -47,6 +47,9 @@ module ThreeScale
       'def report(transactions: [], service_id: nil).'.freeze
     private_constant :DEPRECATION_MSG_OLD_REPORT
 
+    EXTENSIONS_HEADER = '3scale-options'.freeze
+    private_constant :EXTENSIONS_HEADER
+
     def initialize(options)
       if options[:provider_key].nil? || options[:provider_key] =~ /^\s*$/
         raise ArgumentError, 'missing :provider_key'
@@ -381,6 +384,25 @@ module ThreeScale
       response = klass.new
       response.error!(node.content.to_s.strip, node['code'].to_s.strip)
       response
+    end
+
+    # Encode extensions header
+    def extensions_to_header(extensions)
+      {
+        EXTENSIONS_HEADER => extensions.map do |hk, hv|
+          "#{extension_encode(hk.to_s)}=#{extension_encode(hv.to_s)}"
+        end.join('&'.freeze)
+      }
+    end
+
+    # This helper method effectively escapes URI unsafe and separator (&) and
+    # assignment (=) values. Must be fed just keys or values, not a string
+    # representing assignment or multiple parameters (which would need a
+    # separator).
+    def extension_encode(s)
+      URI.encode(s).split('%'.freeze).map do |sub_s|
+        CGI.escape sub_s
+      end.join('%'.freeze)
     end
   end
 end

--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -286,10 +286,8 @@ module ThreeScale
 
     private
 
-    # The support for the 'hierarchy' param is experimental. Its support is not
-    # guaranteed for future versions.
-    OAUTH_PARAMS = [:app_id, :app_key, :service_id, :redirect_url, :usage, :hierarchy]
-    ALL_PARAMS = [:user_key, :app_id, :app_key, :service_id, :redirect_url, :usage, :hierarchy]
+    OAUTH_PARAMS = [:app_id, :app_key, :service_id, :redirect_url, :usage]
+    ALL_PARAMS = [:user_key, :app_id, :app_key, :service_id, :redirect_url, :usage]
     REPORT_PARAMS = [:user_key, :app_id, :service_id, :timestamp]
 
     def options_to_params(options, allowed_keys)

--- a/lib/3scale/client/http_client.rb
+++ b/lib/3scale/client/http_client.rb
@@ -39,19 +39,31 @@ module ThreeScale
           @port = port
         end
 
-        def get_request(path)
+        def get_request(path, headers: nil)
           get = Net::HTTP::Get.new(path)
           get.add_field(*USER_CLIENT_HEADER)
           get.add_field('Host', @host)
+          add_request_headers(get, headers) if headers
           get
         end
 
-        def post_request(path, payload)
+        def post_request(path, payload, headers: nil)
           post = Net::HTTP::Post.new(path)
           post.add_field(*USER_CLIENT_HEADER)
           post.add_field('Host', @host)
+          add_request_headers(post, headers) if headers
           post.set_form_data(payload)
           post
+        end
+
+        private
+
+        def add_request_headers(req, headers)
+          if headers
+            headers.each do |hk, hv|
+              req.add_field(hk, hv)
+            end
+          end
         end
       end
 
@@ -77,15 +89,15 @@ module ThreeScale
           @protocol = 'https'
         end
 
-        def get(path)
+        def get(path, headers: nil)
           uri = full_uri(path)
-          @http.request(uri, get_request(path))
+          @http.request(uri, get_request(path, headers: headers))
         end
 
 
-        def post(path, payload)
+        def post(path, payload, headers: nil)
           uri = full_uri(path)
-          @http.request(uri, post_request(path, payload))
+          @http.request(uri, post_request(path, payload, headers: headers))
         end
 
         def full_uri(path)
@@ -107,12 +119,12 @@ module ThreeScale
           @http.use_ssl = true
         end
 
-        def get(path)
-          @http.request get_request(path)
+        def get(path, headers: nil)
+          @http.request get_request(path, headers: headers)
         end
 
-        def post(path, payload)
-          @http.request post_request(path, payload)
+        def post(path, payload, headers: nil)
+          @http.request post_request(path, payload, headers: headers)
         end
       end
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -267,7 +267,7 @@ class ThreeScale::ClientTest < MiniTest::Test
     # calls.
     urls = [:authorize, :authrep, :oauth_authorize].inject({}) do |acc, method|
       acc[method] = "http://#{@host}/transactions/#{method}.xml?"\
-                    "provider_key=1234abcd&app_id=foo&hierarchy=1"
+                    "provider_key=1234abcd&app_id=foo"
       acc[method] << "&%5Busage%5D%5Bhits%5D=1" if method == :authrep
       acc
     end
@@ -317,7 +317,7 @@ class ThreeScale::ClientTest < MiniTest::Test
 
     urls.each do |method, url|
       FakeWeb.register_uri(:get, url, :status => ['200', 'OK'], :body => body)
-      response = @client.send(method, :app_id => 'foo', :hierarchy => 1)
+      response = @client.send(method, :app_id => 'foo', extensions: { :hierarchy => 1 })
       assert_equal response.hierarchy, { 'parent1' => ['child1', 'child2'],
                                          'parent2' => ['child3'] }
     end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -702,6 +702,56 @@ class ThreeScale::ClientTest < MiniTest::Test
     assert_equal "su1.3scale.net", request["host"]
   end
 
+  EXTENSIONS_HASH = { 'a special &=key' => 'a special =&value' }
+  private_constant :EXTENSIONS_HASH
+  EXTENSIONS_STR  = 'a%20special%20%26%3Dkey=a%20special%20%3D%26value'
+  private_constant :EXTENSIONS_STR
+
+  def test_authorize_with_extensions
+    body = '<status>
+              <authorized>true</authorized>
+              <plan>Ultimate</plan>
+            </status>'
+    FakeWeb.register_uri(:get,
+                         "http://#{@host}/transactions/authorize.xml?provider_key=1234abcd&app_id=foo",
+                         :status => ['200', 'OK'], body: body)
+
+    @client.authorize(:app_id => 'foo', extensions: EXTENSIONS_HASH)
+
+    request = FakeWeb.last_request
+    assert_equal EXTENSIONS_STR, request[ThreeScale::Client.const_get('EXTENSIONS_HEADER')]
+  end
+
+  def test_authrep_with_extensions
+    body = '<status>
+              <authorized>true</authorized>
+              <plan>Ultimate</plan>
+            </status>'
+    FakeWeb.register_uri(:get,
+                         "http://#{@host}/transactions/authrep.xml?provider_key=1234abcd&app_id=foo&%5Busage%5D%5Bhits%5D=1",
+                         :status => ['200', 'OK'], body: body)
+
+    @client.authrep(:app_id => 'foo', extensions: EXTENSIONS_HASH)
+
+    request = FakeWeb.last_request
+    assert_equal EXTENSIONS_STR, request['3scale-options']
+  end
+
+  def test_report_with_extensions
+    FakeWeb.register_uri(:post, "http://#{@host}/transactions.xml",
+                         :status => ['200', 'OK'])
+
+    transactions = [{ :app_id    => 'app_id_1',
+                      :usage     => { 'hits' => 1 },
+                      :timestamp => '2016-07-18 15:42:17 0200' }]
+
+    @client.report(transactions: transactions, service_id: 'a_service_id',
+                   extensions: EXTENSIONS_HASH)
+
+    request = FakeWeb.last_request
+    assert_equal EXTENSIONS_STR, request['3scale-options']
+  end
+
   private
 
   #OPTIMIZE this tricky test helper relies on fakeweb catching the urls requested by the client


### PR DESCRIPTION
This adds support for specifying opt-in features and API extensions using the `3scale-options` header.

Due to limitations in the interface I have opted to add an `extensions` symbol to the `options` hash that several calls accept (which makes the string "extensions" unavailable as a parameter name, which is a bad side effect, but currently ok until we redesign it).