### PR TITLE
Support Rack query encoding in extensions

### DIFF
--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -7,6 +7,7 @@ require '3scale/client/version'
 
 require '3scale/response'
 require '3scale/authorize_response'
+require '3scale/rack_query'
 
 module ThreeScale
   Error = Class.new(RuntimeError)
@@ -394,21 +395,7 @@ module ThreeScale
 
     # Encode extensions header
     def extensions_to_header(extensions)
-      {
-        EXTENSIONS_HEADER => extensions.map do |hk, hv|
-          "#{extension_encode(hk.to_s)}=#{extension_encode(hv.to_s)}"
-        end.join('&'.freeze)
-      }
-    end
-
-    # This helper method effectively escapes URI unsafe and separator (&) and
-    # assignment (=) values. Must be fed just keys or values, not a string
-    # representing assignment or multiple parameters (which would need a
-    # separator).
-    def extension_encode(s)
-      URI.encode(s).split('%'.freeze).map do |sub_s|
-        CGI.escape sub_s
-      end.join('%'.freeze)
+      { EXTENSIONS_HEADER => RackQuery.encode(extensions) }
     end
   end
 end

--- a/lib/3scale/rack_query.rb
+++ b/lib/3scale/rack_query.rb
@@ -1,0 +1,37 @@
+# A simple module to encode hashes of param keys and values as expected by
+# Rack in its nested queries parsing.
+#
+module RackQuery
+  class << self
+    def encode(hash)
+      hash.flat_map do |hk, hv|
+        encode_value(CGI.escape(hk.to_s), hv)
+      end.join('&'.freeze)
+    end
+
+    private
+
+    def encode_value(rack_param, val)
+      if val.is_a? Array
+        encode_array(rack_param, val)
+      elsif val.is_a? Hash
+        encode_hash(rack_param, val)
+      else
+        "#{rack_param}=#{CGI.escape(val.to_s)}"
+      end
+    end
+
+    def encode_array(rack_param, val)
+      rack_param = rack_param + '[]'
+      val.flat_map do |v|
+        encode_value(rack_param, v)
+      end
+    end
+
+    def encode_hash(rack_param, val)
+      val.flat_map do |k, v|
+        encode_value(rack_param + "[#{CGI.escape(k.to_s)}]", v)
+      end
+    end
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -702,9 +702,18 @@ class ThreeScale::ClientTest < MiniTest::Test
     assert_equal "su1.3scale.net", request["host"]
   end
 
-  EXTENSIONS_HASH = { 'a special &=key' => 'a special =&value' }
+  EXTENSIONS_HASH = {
+    'a special &=key' => 'a special =&value',
+    'ary' => [1,2],
+    'a hash' => { one: 'one', two: 'two' },
+    'combined' =>
+      { v: 'v', nested: [1, { h: [ { hh: [ { hhh: :deep }, 'val' ] } ], h2: :h2 } ] }
+  }
   private_constant :EXTENSIONS_HASH
-  EXTENSIONS_STR  = 'a%20special%20%26%3Dkey=a%20special%20%3D%26value'
+  EXTENSIONS_STR  = "a+special+%26%3Dkey=a+special+%3D%26value&ary[]=1&ary[]=2&" \
+                    "a+hash[one]=one&a+hash[two]=two&combined[v]=v&" \
+                    "combined[nested][]=1&combined[nested][][h][][hh][][hhh]=deep&" \
+                    "combined[nested][][h][][hh][]=val&combined[nested][][h2]=h2".freeze
   private_constant :EXTENSIONS_STR
 
   def test_authorize_with_extensions


### PR DESCRIPTION
PR #42 did only support plain keys and values. This one supports specifying arrays and hashes and converting them to the Rack's nested query format. The only meaningful change in the output is that spaces get converted to `+` instead of `%20`, but 3scale supports both, so no problem there.

While at it also modify the client's tests to allow specifying a port. Note that the support for this format is tested in a big test that itself exercises all cases (also tested againsta a live 3scale backend). Would be good to split that into small unit tests for the `rack_query` module.