### PR TITLE
Disable deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ client.authrep(service_id: '123', usage: usage)
 > NOTE: `service_id` is mandatory since November 2016, both when using service
 tokens and when using provider keys
 
+> NOTE: You might use the option `warn_deprecated: false` to avoid deprecation
+warnings. This is enabled by default.
+
 ### SSL and Persistence
 
 Starting with version 2.4.0 you can use two more options: `secure` and `persistent` like:

--- a/lib/3scale/client.rb
+++ b/lib/3scale/client.rb
@@ -60,6 +60,7 @@ module ThreeScale
     def initialize(options)
       @provider_key = options[:provider_key]
       @service_tokens = options[:service_tokens]
+      @warn_deprecated = options.fetch(:warn_deprecated, true)
 
       generate_creds_params
 
@@ -168,7 +169,7 @@ module ThreeScale
       transactions = transactions.concat(reports)
 
       unless rest.empty?
-        warn(DEPRECATION_MSG_OLD_REPORT)
+        warn DEPRECATION_MSG_OLD_REPORT if @warn_deprecated
         transactions.concat([rest])
       end
 
@@ -424,7 +425,7 @@ module ThreeScale
             'service_token='.freeze + CGI.escape(token)
           end
         elsif @provider_key
-          warn DEPRECATION_MSG_PROVIDER_KEY
+          warn DEPRECATION_MSG_PROVIDER_KEY if @warn_deprecated
           lambda do |_|
             "provider_key=#{CGI.escape @provider_key}".freeze
           end

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -2,12 +2,21 @@ require 'benchmark'
 
 require '3scale/client'
 
-provider_key = ENV['TEST_3SCALE_PROVIDER_KEY']
+provider_key = ENV['TEST_3SCALE_PROVIDER_KEY'] or raise 'No provider key set'
+warn_deprecated = ENV['WARN_DEPRECATED'] == '1'
 
-client = ThreeScale::Client.new(:provider_key => provider_key)
-persistent_client = ThreeScale::Client.new(:provider_key => provider_key, :persistent => true)
-persistent_ssl_client = ThreeScale::Client.new(:provider_key => provider_key, :secure => true, :persistent => true)
-ssl_client = ThreeScale::Client.new(:provider_key => provider_key, :secure => true)
+client = ThreeScale::Client.new(provider_key: provider_key,
+                                warn_deprecated: warn_deprecated)
+persistent_client = ThreeScale::Client.new(provider_key: provider_key,
+                                           warn_deprecated: warn_deprecated,
+                                           persistent: true)
+persistent_ssl_client = ThreeScale::Client.new(provider_key: provider_key,
+					       warn_deprecated: warn_deprecated,
+                                               secure: true,
+                                               persistent: true)
+ssl_client = ThreeScale::Client.new(provider_key: provider_key,
+                                    warn_deprecated: warn_deprecated,
+                                    secure: true)
 
 auth = { :app_id => ENV['TEST_3SCALE_APP_IDS'], :app_key => ENV['TEST_3SCALE_APP_KEYS'] }
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -7,8 +7,11 @@ require '3scale/client'
 
 class ThreeScale::ClientTest < MiniTest::Test
 
+  WARN_DEPRECATED = ENV['WARN_DEPRECATED'] == '1'
+
   def client(options = {})
-    ThreeScale::Client.new({:provider_key => '1234abcd'}.merge(options))
+    ThreeScale::Client.new({ provider_key: '1234abcd',
+                             warn_deprecated: WARN_DEPRECATED }.merge(options))
   end
 
   def setup
@@ -29,34 +32,43 @@ class ThreeScale::ClientTest < MiniTest::Test
   end
 
   def test_does_not_raise_if_some_credentials_are_specified
-    assert ThreeScale::Client.new(provider_key: 'some_key')
+    assert ThreeScale::Client.new(provider_key: 'some_key',
+                                  warn_deprecated: WARN_DEPRECATED)
     assert ThreeScale::Client.new(service_tokens: true)
   end
 
   def test_default_host
-    client = ThreeScale::Client.new(:provider_key => '1234abcd')
+    client = ThreeScale::Client.new(provider_key: '1234abcd',
+                                    warn_deprecated: WARN_DEPRECATED)
 
     assert_equal 'su1.3scale.net', client.host
   end
 
   def test_custom_host
-    client = ThreeScale::Client.new(:provider_key => '1234abcd', :host => "example.com")
+    client = ThreeScale::Client.new(provider_key: '1234abcd',
+                                    warn_deprecated: WARN_DEPRECATED,
+                                    host: "example.com")
 
     assert_equal 'example.com', client.host
   end
 
   def test_default_protocol
-    client = ThreeScale::Client.new(:provider_key => 'test')
+    client = ThreeScale::Client.new(provider_key: 'test',
+                                    warn_deprecated: WARN_DEPRECATED)
     assert_equal false, client.http.use_ssl?
   end
 
   def test_insecure_protocol
-    client = ThreeScale::Client.new(:provider_key => 'test', :secure => false)
+    client = ThreeScale::Client.new(provider_key: 'test',
+                                    warn_deprecated: WARN_DEPRECATED,
+                                    secure: false)
     assert_equal false, client.http.use_ssl?
   end
 
   def test_secure_protocol
-    client = ThreeScale::Client.new(:provider_key => 'test', :secure => true)
+    client = ThreeScale::Client.new(provider_key: 'test',
+                                    warn_deprecated: WARN_DEPRECATED,
+                                    secure: true)
     assert_equal true, client.http.use_ssl?
   end
 
@@ -639,7 +651,8 @@ class ThreeScale::ClientTest < MiniTest::Test
                          :status => ['403', 'Forbidden'],
                          :body   => error_body)
 
-    client   = ThreeScale::Client.new(:provider_key => 'foo')
+    client   = ThreeScale::Client.new(provider_key: 'foo',
+                                      warn_deprecated: WARN_DEPRECATED)
     transactions = [{ :app_id => 'abc', :usage => { 'hits' => 1 } }]
     response = client.report(transactions: transactions)
 
@@ -667,7 +680,8 @@ class ThreeScale::ClientTest < MiniTest::Test
                          :status => ['200', 'OK'],
                          :body   => success_body)
 
-    client = ThreeScale::Client.new(:provider_key => 'foo')
+    client = ThreeScale::Client.new(provider_key: 'foo',
+                                    warn_deprecated: WARN_DEPRECATED)
     response = client.authorize(:app_id => 'foo')
 
     assert response.success?
@@ -684,7 +698,8 @@ class ThreeScale::ClientTest < MiniTest::Test
     FakeWeb.register_uri(:post, "http://#{@host}/transactions.xml",
                          :status => ['200', 'OK'],
                          :body   => success_body)
-    client = ThreeScale::Client.new(:provider_key => 'foo')
+    client = ThreeScale::Client.new(provider_key: 'foo',
+                                    warn_deprecated: WARN_DEPRECATED)
     transactions = [{ :app_id => 'abc', :usage => { 'hits' => 1 } }]
     client.report(transactions: transactions)
 
@@ -700,7 +715,8 @@ class ThreeScale::ClientTest < MiniTest::Test
                          :status => ['200', 'OK'],
                          :body   => success_body)
 
-    client = ThreeScale::Client.new(:provider_key => 'foo')
+    client = ThreeScale::Client.new(provider_key: 'foo',
+                                    warn_deprecated: WARN_DEPRECATED)
     response = client.authrep(:app_id => 'abc')
 
     assert response.success?
@@ -847,7 +863,10 @@ end
 class ThreeScale::NetHttpPersistentClientTest < ThreeScale::ClientTest
   def client(options = {})
     ThreeScale::Client::HTTPClient.persistent_backend = ThreeScale::Client::HTTPClient::NetHttpPersistent
-    ThreeScale::Client.new({:provider_key => '1234abcd', :persistent => true}.merge(options))
+    ThreeScale::Client.new({ provider_key: '1234abcd',
+                             warn_deprecated: WARN_DEPRECATED,
+                             persistent: true,
+                           }.merge(options))
   end
 end
 

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -5,6 +5,8 @@ require 'mocha/setup'
 
 if ENV['TEST_3SCALE_PROVIDER_KEY'] && ENV['TEST_3SCALE_APP_IDS'] && ENV['TEST_3SCALE_APP_KEYS']
   class ThreeScale::NetHttpPersistenceTest < MiniTest::Test
+    WARN_DEPRECATED = ENV['WARN_DEPRECATED'] == '1'
+
     def setup
       ThreeScale::Client::HTTPClient.persistent_backend = ThreeScale::Client::HTTPClient::NetHttpPersistent
 
@@ -13,7 +15,9 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] && ENV['TEST_3SCALE_APP_IDS'] && ENV['TEST_3S
       @app_id = ENV['TEST_3SCALE_APP_IDS']
       @app_key = ENV['TEST_3SCALE_APP_KEYS']
 
-      @client = ThreeScale::Client.new(provider_key: provider_key, persistence: true)
+      @client = ThreeScale::Client.new(provider_key: provider_key,
+				       warn_deprecated: WARN_DEPRECATED,
+                                       persistence: true)
 
       if defined?(FakeWeb)
         FakeWeb.allow_net_connect = true

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -5,6 +5,8 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
    ENV['TEST_3SCALE_APP_IDS']      &&
    ENV['TEST_3SCALE_APP_KEYS']
   class ThreeScale::RemoteTest < MiniTest::Test
+    WARN_DEPRECATED = ENV['WARN_DEPRECATED'] == '1'
+
     def setup
       @provider_key = ENV['TEST_3SCALE_PROVIDER_KEY']
 
@@ -13,7 +15,8 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
       @app_ids  = ENV['TEST_3SCALE_APP_IDS'].split(',').map(&stripper)
       @app_keys = ENV['TEST_3SCALE_APP_KEYS'].split(',').map(&stripper)
 
-      @client = ThreeScale::Client.new(:provider_key => @provider_key)
+      @client = ThreeScale::Client.new(provider_key: @provider_key,
+                                       warn_deprecated: WARN_DEPRECATED)
 
       if defined?(FakeWeb)
         FakeWeb.clean_registry
@@ -39,7 +42,9 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
     end
 
     def test_successful_secure_authrep
-      @client = ThreeScale::Client.new(:provider_key => @provider_key, :secure => true)
+      @client = ThreeScale::Client.new(provider_key: @provider_key,
+                                       warn_deprecated: WARN_DEPRECATED,
+                                       secure: true)
       test_successful_authrep
     end
 
@@ -96,7 +101,8 @@ if ENV['TEST_3SCALE_PROVIDER_KEY'] &&
         {:app_id => app_id, :usage => {'hits' => 1}}
       end
 
-      client   = ThreeScale::Client.new(:provider_key => 'invalid-key')
+      client   = ThreeScale::Client.new(provider_key: 'invalid-key',
+                                        warn_deprecated: WARN_DEPRECATED)
       response = client.report(transactions: transactions)
       assert !response.success?
       assert_equal 'provider_key_invalid',                  response.error_code


### PR DESCRIPTION
This introduces the optional parameter `warn_deprecated` defaulting to `true` when initializing a client. This way people that *know* what their usage is can make a conscious decision to skip the warnings.