### PR TITLE
adds an ansible playbook that installs the development prerequisites …

### DIFF
--- a/install-deps-playbook.yml
+++ b/install-deps-playbook.yml
@@ -1,0 +1,50 @@
+---
+  - name: Install 3scale gem Dependencies
+    hosts: 3scale-dev
+    #become: yes
+    become_user: root
+    user: ec2-user
+    tasks:
+        - name: Install Development Tools
+          become: yes
+          yum:
+              name: "@Development Tools"
+              state: present
+
+        - name: Install SSL headers
+          become: yes
+          yum:
+            name: 'openssl-devel'
+            state: present
+        - name: Install readline-devel
+          become: yes
+          yum:
+            name: 'readline-devel'
+            state: present
+
+        - name: Clone rbenv
+          ansible.builtin.git:
+            repo: 'https://github.com/rbenv/rbenv.git'
+            dest: '~/.rbenv'
+            clone: yes
+
+        - name: Add rbenv to path
+          lineinfile:
+            path: '~/.bash_profile'
+            regexp: '^PATH='
+            line: 'PATH=$HOME/.rbenv/bin:$PATH:$HOME/.local/bin:$HOME/bin'
+
+        - name: Create rbenv plugins directory
+          file:
+            path: '~/.rbenv/plugins'
+            state: directory
+            recurse: yes
+            owner: ec2-user
+            group: ec2-user
+
+        - name: Install ruby-build
+          ansible.builtin.git:
+            repo: 'https://github.com/rbenv/ruby-build.git'
+            dest: '~/.rbenv/plugins/ruby-build'
+            clone: yes
+


### PR DESCRIPTION
…on an Amazon Linux 2 EC2 instance.

It installs Development Tools, the ssl library version 1.0, rbenv and ruby-build.

Subsequent steps to take after seeding the machine with these would be to run
`rbenv install 2.3.8`
`rbenv init`

Add the line it suggests to ~/.bash_profile and then
`source ~/.bash_profile`

and lastly:
`rbenv shell 2.3.8`

This has all been done already for the `ec2-user` on the new host as of this writing.